### PR TITLE
请升级com.thoughtworks.xstream:xstream组件版本以解决32个安全漏洞

### DIFF
--- a/redis-manager-dashboard/pom.xml
+++ b/redis-manager-dashboard/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
-            <version>2.1.5.RELEASE</version>
+            <version>2.1.6.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
将 **org.springframework.cloud:spring-cloud-starter-netflix-eureka-server** 组件从2.1.5.RELEASE 版本升级至 2.1.6.RELEASE版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2021-36984](https://www.oscs1024.com/hd/MPS-2021-36984) | XStream < 1.4.19存在拒绝服务漏洞 | 高危
2 | [MPS-2020-17661](https://www.oscs1024.com/hd/MPS-2020-17661) | Xstream < 1.4.15存在删除任意文件漏洞 | 中危
3 | [MPS-2021-17822](https://www.oscs1024.com/hd/MPS-2021-17822) | XStream < 1.4.18存在任意代码执行漏洞 | 高危
4 | [MPS-2021-17821](https://www.oscs1024.com/hd/MPS-2021-17821) | XStream < 1.4.18 任意代码执行漏洞 | 高危
5 | [MPS-2021-17813](https://www.oscs1024.com/hd/MPS-2021-17813) | XStream < 1.4.18 存在服务器端请求伪造漏洞 | 高危
6 | [MPS-2021-17818](https://www.oscs1024.com/hd/MPS-2021-17818) | XStream < 1.4.18存在任意代码执行漏洞 | 高危
7 | [MPS-2020-17361](https://www.oscs1024.com/hd/MPS-2020-17361) | XStream 操作系统命令注入漏洞 | 高危
8 | [MPS-2021-3119](https://www.oscs1024.com/hd/MPS-2021-3119) | XStream <1.4.16存在反序列化漏洞 | 高危
9 | [MPS-2021-3122](https://www.oscs1024.com/hd/MPS-2021-3122) | XStream 存在反序列化漏洞 | 高危
10 | [MPS-2021-3125](https://www.oscs1024.com/hd/MPS-2021-3125) | XStream 存在反序列化漏洞 | 高危
11 | [MPS-2021-3128](https://www.oscs1024.com/hd/MPS-2021-3128) | XStream <1.4.16存在反序列化漏洞 | 高危
12 | [MPS-2021-3123](https://www.oscs1024.com/hd/MPS-2021-3123) | XStream <1.4.16存在反序列化漏洞 | 中危
13 | [MPS-2021-7164](https://www.oscs1024.com/hd/MPS-2021-7164) | XStream 远程代码执行漏洞 | 高危
14 | [MPS-2021-17824](https://www.oscs1024.com/hd/MPS-2021-17824) | XStream < 1.4.18存在任意代码执行 | 高危
15 | [MPS-2020-17591](https://www.oscs1024.com/hd/MPS-2020-17591) | XStream < 1.4.15存在服务端请求伪造漏洞 | 高危
16 | [MPS-2021-3121](https://www.oscs1024.com/hd/MPS-2021-3121) | XStream 存在反序列化漏洞 | 高危
17 | [MPS-2021-3120](https://www.oscs1024.com/hd/MPS-2021-3120) | XStream 存在反序列化漏洞 | 中危
18 | [MPS-2021-3127](https://www.oscs1024.com/hd/MPS-2021-3127) | XStream 存在反序列化漏洞 | 中危
19 | [MPS-2021-3396](https://www.oscs1024.com/hd/MPS-2021-3396) | XStream 存在反序列化漏洞 | 高危
20 | [MPS-2021-3129](https://www.oscs1024.com/hd/MPS-2021-3129) | XStream 存在反序列化漏洞 | 严重
21 | [MPS-2021-17819](https://www.oscs1024.com/hd/MPS-2021-17819) | XStream <1.4.18存在任意代码执行漏洞 | 高危
22 | [MPS-2021-17816](https://www.oscs1024.com/hd/MPS-2021-17816) | XStream < 1.4.18存在任意代码执行漏洞 | 高危
23 | [MPS-2021-17812](https://www.oscs1024.com/hd/MPS-2021-17812) | XStream  <1.4.18 存在服务器端伪造请求漏洞 | 高危
24 | [MPS-2021-17814](https://www.oscs1024.com/hd/MPS-2021-17814) | XStream 存在拒绝服务漏洞 | 中危
25 | [MPS-2021-17823](https://www.oscs1024.com/hd/MPS-2021-17823) | XStream <1.4.18存在任意代码执行漏洞 | 高危
26 | [MPS-2021-17817](https://www.oscs1024.com/hd/MPS-2021-17817) | XStream < 1.4.18存在任意代码执行漏洞 | 高危
27 | [MPS-2021-17820](https://www.oscs1024.com/hd/MPS-2021-17820) | XStream < 1.4.18存在任意代码执行漏洞 | 高危
28 | [MPS-2021-3124](https://www.oscs1024.com/hd/MPS-2021-3124) | XStream 存在拒绝服务漏洞 | 中危
29 | [MPS-2022-58603](https://www.oscs1024.com/hd/MPS-2022-58603) | XStream < 1.4.20 栈缓冲区溢出漏洞 | 中危
30 | [MPS-2022-57066](https://www.oscs1024.com/hd/MPS-2022-57066) | xstream project跨界内存写漏洞 | 高危
31 | [MPS-2021-17815](https://www.oscs1024.com/hd/MPS-2021-17815) | XStream < 1.4.18存在任意代码执行漏洞 | 高危
32 | [MPS-2021-17825](https://www.oscs1024.com/hd/MPS-2021-17825) | XStream < 1.4.18 反序列化远程代码执行漏洞 | 高危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
